### PR TITLE
Replacing WS and HTTP in uri schemes only by matching only once. 

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -2,6 +2,7 @@ import * as http from "httpie";
 import { getItem, setItem, removeItem } from "./Storage";
 
 const TOKEN_STORAGE = "colyseus-auth-token";
+const WS_REGEX = "^(?:ws)";
 
 export enum Platform {
     ios = "ios",
@@ -81,7 +82,7 @@ export class Auth implements IUser {
     protected keepOnlineInterval: any;
 
     constructor(endpoint: string) {
-        this.endpoint = endpoint.replace("ws", "http");
+        this.endpoint = endpoint.replace(WS_REGEX, "http");
         getItem(TOKEN_STORAGE, (token) => this.token = token);
     }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -5,6 +5,9 @@ import { Auth } from './Auth';
 import { Push } from './Push';
 import { RootSchemaConstructor } from './serializer/SchemaSerializer';
 
+const WS_REGEX = "^(?:ws)";
+const HTTP_REGEX = "^(?:http)";
+
 export type JoinOptions = any;
 
 export class MatchMakeError extends Error {
@@ -22,7 +25,7 @@ export class Client {
 
     protected endpoint: string;
 
-    constructor(endpoint: string = `${location.protocol.replace("http", "ws")}//${location.hostname}${(location.port && `:${location.port}`)}`) {
+    constructor(endpoint: string = `${location.protocol.replace(HTTP_REGEX, "ws")}//${location.hostname}${(location.port && `:${location.port}`)}`) {
         this.endpoint = endpoint;
         this.auth = new Auth(this.endpoint);
         this.push = new Push(this.endpoint);
@@ -49,7 +52,7 @@ export class Client {
     }
 
     public async getAvailableRooms<Metadata= any>(roomName: string = ""): Promise<RoomAvailable<Metadata>[]> {
-        const url = `${this.endpoint.replace("ws", "http")}/matchmake/${roomName}`;
+        const url = `${this.endpoint.replace(WS_REGEX, "http")}/matchmake/${roomName}`;
         return (await get(url, { headers: { 'Accept': 'application/json' } })).data;
     }
 
@@ -77,7 +80,7 @@ export class Client {
         options: JoinOptions = {},
         rootSchema?: RootSchemaConstructor
     ) {
-        const url = `${this.endpoint.replace("ws", "http")}/matchmake/${method}/${roomName}`;
+        const url = `${this.endpoint.replace(WS_REGEX, "http")}/matchmake/${method}/${roomName}`;
 
         // automatically forward auth token, if present
         if (this.auth.hasToken) {

--- a/src/Push.ts
+++ b/src/Push.ts
@@ -1,8 +1,10 @@
+const WS_REGEX = "^(?:ws)";
+
 export class Push {
     endpoint: string;
 
     constructor (endpoint: string) {
-        this.endpoint = endpoint.replace("ws", "http");
+        this.endpoint = endpoint.replace(WS_REGEX, "http");
     }
 
     public async register() {


### PR DESCRIPTION
Had a problem with AWS EC2 hostnames containing the same 'ws' characters as the uri scheme.