### PR TITLE
#68 Use HTTPS when client endpoint uses WSS

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -81,7 +81,7 @@ export class Auth implements IUser {
     protected keepOnlineInterval: any;
 
     constructor(endpoint: string) {
-        this.endpoint = endpoint.replace("ws", "http");
+        this.endpoint = endpoint;
         getItem(TOKEN_STORAGE, (token) => this.token = token);
     }
 

--- a/src/Push.ts
+++ b/src/Push.ts
@@ -2,7 +2,7 @@ export class Push {
     endpoint: string;
 
     constructor (endpoint: string) {
-        this.endpoint = endpoint.replace("ws", "http");
+        this.endpoint = endpoint;
     }
 
     public async register() {


### PR DESCRIPTION
To fix issues with mixed content, HTTP requests should use HTTPS when the endpoint uses wss://. When the endpoint uses ws://, http:// is used for HTTP requests. This might fix #68.