### PR TITLE
[Security] Make login parameters to be passed via body instead of query

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -102,7 +102,9 @@ export class Auth implements IUser {
             bodyParams.token = this.token;
         }
 
-        const data = await this.request('post', '/auth', {}, bodyParams);
+        const data = await this.request('post', '/auth', {}, bodyParams, {
+            'Content-Type': 'application/json',
+        });
 
         // set & cache token
         this.token = data.token;

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -96,13 +96,13 @@ export class Auth implements IUser {
         email?: string,
         password?: string,
     } = {}) {
-        const queryParams: any = Object.assign({}, options);
+        const bodyParams: any = Object.assign({}, options);
 
         if (this.hasToken) {
-            queryParams.token = this.token;
+            bodyParams.token = this.token;
         }
 
-        const data = await this.request('post', '/auth', queryParams);
+        const data = await this.request('post', '/auth', {}, bodyParams);
 
         // set & cache token
         this.token = data.token;


### PR DESCRIPTION
Currently there is a big security issue with the auth feature.

It passes email, password, Facebook access token etc in the GET query, meaning anyone who monitors your web requests including you ISP, router owner etc can see them. Web requests also stay in router logs etc.

Instead they should be passed in the request body and thus encrypted when using HTTPS.

This PR fixes that. I am aware it impacts `@colyseus/colyseus-social` so I will follow up with PR there as well.

Edit: https://github.com/colyseus/colyseus-social/pull/26