### PR TITLE
Custom headers and query params in connection

### DIFF
--- a/test/client_test.ts
+++ b/test/client_test.ts
@@ -40,6 +40,18 @@ describe("Client", function () {
                     wsEndpoint: "wss://localhost/custom/path/processId/roomId?",
                     wsEndpointPublicAddress: "wss://node-1.colyseus.cloud/processId/roomId?"
                 },
+                'https://localhost/with/header': {
+                    settings: { hostname: "localhost", port: 443, secure: true, pathname: "/with/header", headers: { "Authorization": "Bearer ey21xx"} },
+                    httpEndpoint: "https://localhost/with/header",
+                    wsEndpoint: "wss://localhost/with/header/processId/roomId?",
+                    wsEndpointPublicAddress: "wss://node-1.colyseus.cloud/processId/roomId?"
+                },
+                'https://localhost/custom/path?query=value': {
+                    settings: { hostname: "localhost", port: 443, secure: true, pathname: "/custom/path", query: new URLSearchParams({"query": "value"}) },
+                    httpEndpoint: "https://localhost/custom/path",
+                    wsEndpoint: "wss://localhost/custom/path/processId/roomId?query=value",
+                    wsEndpointPublicAddress: "wss://node-1.colyseus.cloud/processId/roomId?query=value"
+                },
             };
 
             for (const url in settingsByUrl) {
@@ -49,6 +61,7 @@ describe("Client", function () {
                 assert.strictEqual(expected.settings.hostname, settings.hostname);
                 assert.strictEqual(expected.settings.port, settings.port);
                 assert.strictEqual(expected.settings.secure, settings.secure);
+                assert.strictEqual(expected.settings.query?.toString(), settings.query?.toString());
                 assert.strictEqual(expected.httpEndpoint + "/matchmake/", client['getHttpEndpoint']());
                 assert.strictEqual(expected.wsEndpoint, client['buildEndpoint'](room));
                 assert.strictEqual(expected.wsEndpointPublicAddress, client['buildEndpoint'](roomWithPublicAddress));

--- a/test/client_test.ts
+++ b/test/client_test.ts
@@ -11,7 +11,7 @@ describe("Client", function () {
     })
 
     describe("constructor settings", () => {
-        it("url string", () => {
+       
             const room = { roomId: "roomId", processId: "processId", sessionId: "sessionId", };
             const roomWithPublicAddress = { publicAddress: "node-1.colyseus.cloud", roomId: "roomId", processId: "processId", sessionId: "sessionId", };
 
@@ -55,6 +55,7 @@ describe("Client", function () {
             };
 
             for (const url in settingsByUrl) {
+             it(`testing settings by url ${url}`, () => {
                 const expected = settingsByUrl[url]
                 const client = new Client(url);
                 const settings = client['settings'];
@@ -73,8 +74,9 @@ describe("Client", function () {
                 assert.strictEqual(expected.httpEndpoint + "/matchmake/", clientWithSettings['getHttpEndpoint']());
                 assert.strictEqual(expected.wsEndpoint, clientWithSettings['buildEndpoint'](room));
                 assert.strictEqual(expected.wsEndpointPublicAddress, clientWithSettings['buildEndpoint'](roomWithPublicAddress));
+             });
             }
-        });
+       
     });
 
     xit("join", function () {


### PR DESCRIPTION
Im evaluating the use of colyseus in a "service mesh"-ish topology where the authn/authz is happening on reverse proxy level. That means websocket upgrade requests + all http requests need a token header or access token in the url query params to pass through the proxy and reach the colyseus upstream. (This is especially useful when scaling horizontally since colyseus replicas do NOT need to deal with authn/authz themselves)

This change would be backwards compatible by allowing optional query parms/headers to be added to every request. 

@endel WDYT 

i would add mock httpie and add tests if the provided headers are landing on the outgoint http requests, if you consider merging