### PR TITLE
Auth API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.15",
+  "version": "0.15.15-preview.16",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.13",
+  "version": "0.15.15-preview.15",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.9",
+  "version": "0.15.15-preview.13",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-alpha.0",
+  "version": "0.15.15-alpha.3",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.14",
+  "version": "0.15.15-alpha.0",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.18",
+  "version": "0.15.15-preview.20",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.21",
+  "version": "0.15.15-preview.22",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.5",
+  "version": "0.15.15-preview.6",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.16",
+  "version": "0.15.15-preview.18",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.6",
+  "version": "0.15.15-preview.7",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-alpha.3",
+  "version": "0.15.15-preview.5",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.7",
+  "version": "0.15.15-preview.9",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus.js",
-  "version": "0.15.15-preview.20",
+  "version": "0.15.15-preview.21",
   "description": "Colyseus Multiplayer SDK for JavaScript/TypeScript",
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -69,7 +69,7 @@ export class Auth {
         return data;
     }
 
-    public async signInWithOAuth(providerName: string, settings: Partial<PopupSettings> = {}) {
+    public async oauth(providerName: string, settings: Partial<PopupSettings> = {}) {
         return new Promise((resolve, reject) => {
             const w = settings.width || 480;
             const h = settings.height || 768;

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -114,9 +114,12 @@ export class Auth {
             const w = settings.width || 480;
             const h = settings.height || 768;
 
+            // forward existing token for upgrading
+            const upgradingToken = this.token ? `?token=${this.token}` : "";
+
             // Capitalize first letter of providerName
             const title = `Login with ${(providerName[0].toUpperCase() + providerName.substring(1))}`;
-            const url = this.http['client']['getHttpEndpoint'](`${(settings.prefix || `${this.settings.path}/provider`)}/${providerName}`);
+            const url = this.http['client']['getHttpEndpoint'](`${(settings.prefix || `${this.settings.path}/provider`)}/${providerName}${upgradingToken}`);
 
             const left = (screen.width / 2) - (w / 2);
             const top = (screen.height / 2) - (h / 2);

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -89,8 +89,20 @@ export class Auth {
         return data;
     }
 
-    public async signInAnonymously() {
-        const data = (await this.http.post(`${this.settings.path}/anonymous`)).data;
+    public async signInAnonymously(options?: any) {
+        const data = (await this.http.post(`${this.settings.path}/anonymous`, {
+            body: { options, }
+        })).data;
+
+        this.emitChange(data);
+
+        return data;
+    }
+
+    public async sendPasswordResetEmail(email: string) {
+        const data = (await this.http.post(`${this.settings.path}/forgot-password`, {
+            body: { email, }
+        })).data;
 
         this.emitChange(data);
 

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -69,10 +69,9 @@ export class Auth {
         }
     }
 
-    public async registerWithEmailAndPassword(email: string, password: string) {
+    public async registerWithEmailAndPassword(email: string, password: string, options?: any) {
         const data = (await this.http.post(`${this.settings.path}/register`, {
-            headers: { 'Content-Type': 'application/json' },
-            body: { email, password, },
+            body: { email, password, options, },
         })).data;
 
         this.emitChange(data);
@@ -82,7 +81,6 @@ export class Auth {
 
     public async signInWithEmailAndPassword(email: string, password: string) {
         const data = (await this.http.post(`${this.settings.path}/login`, {
-            headers: { 'Content-Type': 'application/json' },
             body: { email, password, },
         })).data;
 
@@ -92,9 +90,7 @@ export class Auth {
     }
 
     public async signInAnonymously() {
-        const data = (await this.http.post(`${this.settings.path}/anonymous`, {
-            headers: { 'Content-Type': 'application/json' },
-        })).data;
+        const data = (await this.http.post(`${this.settings.path}/anonymous`)).data;
 
         this.emitChange(data);
 

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -46,7 +46,7 @@ export class Auth {
         if (!this.#_initialized) {
             this.#_initializationPromise = new Promise<void>((resolve, reject) => {
                 this.getUserData().then((userData) => {
-                    this.emitChange(userData);
+                    this.emitChange({ ...userData, token: this.token });
 
                 }).catch((e) => {
                     // user is not logged in, or service is down
@@ -93,7 +93,7 @@ export class Auth {
 
     public async signInAnonymously() {
         const data = (await this.http.post(`${this.settings.path}/anonymous`, {
-            headers: { 'Content-Type': 'application/json' }
+            headers: { 'Content-Type': 'application/json' },
         })).data;
 
         this.emitChange(data);

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -1,5 +1,5 @@
 import { HTTP } from "./HTTP";
-import { getItem, setItem } from "./Storage";
+import { getItem, removeItem, setItem } from "./Storage";
 import { createNanoEvents } from './core/nanoevents';
 
 export interface AuthSettings {
@@ -156,8 +156,14 @@ export class Auth {
     private emitChange(authData: Partial<AuthData>) {
         if (authData.token !== undefined) {
             this.token = authData.token;
-            // store key in localStorage
-            setItem(this.settings.key, authData.token);
+
+            if (authData.token === null) {
+                removeItem(this.settings.key);
+
+            } else {
+                // store key in localStorage
+                setItem(this.settings.key, authData.token);
+            }
         }
 
         this.#_events.emit("change", authData);

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -108,7 +108,7 @@ export class Auth {
 
             // Capitalize first letter of providerName
             const title = `Login with ${(providerName[0].toUpperCase() + providerName.substring(1))}`;
-            const url = this.http['client']['getHttpEndpoint'](`${(settings.prefix || "oauth")}/${providerName}`);
+            const url = this.http['client']['getHttpEndpoint'](`${(settings.prefix || `${this.settings.path}/provider`)}/${providerName}`);
 
             const left = (screen.width / 2) - (w / 2);
             const top = (screen.height / 2) - (h / 2);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -45,7 +45,7 @@ export class Client {
 
             this.settings = {
                 hostname: url.hostname,
-                pathname: url.pathname !== "/" ? url.pathname : "",
+                pathname: url.pathname,
                 port,
                 secure
             };
@@ -61,6 +61,11 @@ export class Client {
                 settings.pathname = "";
             }
             this.settings = settings;
+        }
+
+        // make sure pathname does not end with "/"
+        if (this.settings.pathname.endsWith("/")) {
+            this.settings.pathname = this.settings.pathname.slice(0, -1);
         }
 
         this.http = new HTTP(this);
@@ -100,7 +105,7 @@ export class Client {
 
     public async getAvailableRooms<Metadata = any>(roomName: string = ""): Promise<RoomAvailable<Metadata>[]> {
         return (
-            await this.http.get(`${roomName}`, {
+            await this.http.get(`matchmake/${roomName}`, {
                 headers: {
                     'Accept': 'application/json'
                 }
@@ -171,7 +176,7 @@ export class Client {
         reuseRoomInstance?: Room,
     ) {
         const response = (
-            await this.http.post(`${method}/${roomName}`, {
+            await this.http.post(`matchmake/${method}/${roomName}`, {
                 headers: {
                     'Accept': 'application/json',
                     'Content-Type': 'application/json'
@@ -222,7 +227,7 @@ export class Client {
     }
 
     protected getHttpEndpoint(segments: string = '') {
-        return `${(this.settings.secure) ? "https" : "http"}://${this.settings.hostname}${this.getEndpointPort()}${this.settings.pathname}/matchmake/${segments}`;
+        return `${(this.settings.secure) ? "https" : "http"}://${this.settings.hostname}${this.getEndpointPort()}${this.settings.pathname}/${segments}`;
     }
 
     protected getEndpointPort() {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,8 +1,7 @@
-import { post, get } from "httpie";
-
 import { ServerError } from './errors/ServerError';
 import { Room, RoomAvailable } from './Room';
 import { SchemaConstructor } from './serializer/SchemaSerializer';
+import { HTTP } from "./core/HTTP";
 
 export type JoinOptions = any;
 
@@ -29,6 +28,8 @@ export interface EndpointSettings {
 }
 
 export class Client {
+    public http: HTTP;
+
     protected settings: EndpointSettings;
 
     constructor(settings: string | EndpointSettings = DEFAULT_ENDPOINT) {
@@ -59,6 +60,8 @@ export class Client {
             }
             this.settings = settings;
         }
+
+        this.http = new HTTP(this);
     }
 
     public async joinOrCreate<T>(roomName: string, options: JoinOptions = {}, rootSchema?: SchemaConstructor<T>) {
@@ -94,7 +97,7 @@ export class Client {
 
     public async getAvailableRooms<Metadata = any>(roomName: string = ""): Promise<RoomAvailable<Metadata>[]> {
         return (
-            await get(this.getHttpEndpoint(`${roomName}`), {
+            await this.http.get(`${roomName}`, {
                 headers: {
                     'Accept': 'application/json'
                 }
@@ -165,7 +168,7 @@ export class Client {
         reuseRoomInstance?: Room,
     ) {
         const response = (
-            await post(this.getHttpEndpoint(`${method}/${roomName}`), {
+            await this.http.post(`${method}/${roomName}`, {
                 headers: {
                     'Accept': 'application/json',
                     'Content-Type': 'application/json'

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -227,7 +227,8 @@ export class Client {
     }
 
     protected getHttpEndpoint(segments: string = '') {
-        return `${(this.settings.secure) ? "https" : "http"}://${this.settings.hostname}${this.getEndpointPort()}${this.settings.pathname}/${segments}`;
+        const path = segments.startsWith("/") ? segments : `/${segments}`;
+        return `${(this.settings.secure) ? "https" : "http"}://${this.settings.hostname}${this.getEndpointPort()}${this.settings.pathname}${path}`;
     }
 
     protected getEndpointPort() {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,7 +1,7 @@
 import { ServerError } from './errors/ServerError';
 import { Room, RoomAvailable } from './Room';
 import { SchemaConstructor } from './serializer/SchemaSerializer';
-import { HTTP } from "./core/HTTP";
+import { HTTP } from "./HTTP";
 
 export type JoinOptions = any;
 
@@ -62,6 +62,14 @@ export class Client {
         }
 
         this.http = new HTTP(this);
+    }
+
+    public set authToken(token: string) {
+        this.http.authToken = token;
+    }
+
+    public get authToken(): string {
+        return this.http.authToken;
     }
 
     public async joinOrCreate<T>(roomName: string, options: JoinOptions = {}, rootSchema?: SchemaConstructor<T>) {
@@ -196,6 +204,12 @@ export class Client {
     protected buildEndpoint(room: any, options: any = {}) {
         const params = [];
 
+        // manually append authToken
+        if (this.http.authToken) {
+            params.push(`authToken=${this.http.authToken}`);
+        }
+
+        // append provided options
         for (const name in options) {
             if (!options.hasOwnProperty(name)) {
                 continue;

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -2,6 +2,7 @@ import { ServerError } from './errors/ServerError';
 import { Room, RoomAvailable } from './Room';
 import { SchemaConstructor } from './serializer/SchemaSerializer';
 import { HTTP } from "./HTTP";
+import { Auth } from './Auth';
 
 export type JoinOptions = any;
 
@@ -29,6 +30,7 @@ export interface EndpointSettings {
 
 export class Client {
     public http: HTTP;
+    public auth: Auth;
 
     protected settings: EndpointSettings;
 
@@ -62,14 +64,7 @@ export class Client {
         }
 
         this.http = new HTTP(this);
-    }
-
-    public set authToken(token: string) {
-        this.http.authToken = token;
-    }
-
-    public get authToken(): string {
-        return this.http.authToken;
+        this.auth = new Auth(this.http);
     }
 
     public async joinOrCreate<T>(roomName: string, options: JoinOptions = {}, rootSchema?: SchemaConstructor<T>) {
@@ -203,11 +198,6 @@ export class Client {
 
     protected buildEndpoint(room: any, options: any = {}) {
         const params = [];
-
-        // manually append authToken
-        if (this.http.authToken) {
-            params.push(`authToken=${this.http.authToken}`);
-        }
 
         // append provided options
         for (const name in options) {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -185,6 +185,7 @@ export class Client {
             })
         ).data;
 
+        // FIXME: HTTP class is already handling this as ServerError.
         if (response.error) {
             throw new MatchMakeError(response.error, response.code);
         }

--- a/src/HTTP.ts
+++ b/src/HTTP.ts
@@ -7,19 +7,19 @@ export class HTTP {
     constructor(protected client: Client) {}
 
     public get<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return get(this.client['getHttpEndpoint'](path), options);
+        return get(this.client['getHttpEndpoint'](path), this.getOptions(options));
     }
 
     public post<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return post(this.client['getHttpEndpoint'](path), options);
+        return post(this.client['getHttpEndpoint'](path), this.getOptions(options));
     }
 
     public del<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return del(this.client['getHttpEndpoint'](path), options);
+        return del(this.client['getHttpEndpoint'](path), this.getOptions(options));
     }
 
     public put<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return put(this.client['getHttpEndpoint'](path), options);
+        return put(this.client['getHttpEndpoint'](path), this.getOptions(options));
     }
 
     protected getOptions(options: Partial<Options>) {
@@ -29,6 +29,7 @@ export class HTTP {
             }
 
             options.headers['Authorization'] = `Bearer ${this.authToken}`;
+            options.withCredentials = true;
         }
 
         return options;

--- a/src/HTTP.ts
+++ b/src/HTTP.ts
@@ -1,5 +1,6 @@
 import { Client } from "./Client";
-import { post, get, put, del, Response, Options } from "httpie";
+import { ServerError } from "./errors/ServerError";
+import httpie, { Response, Options } from "httpie";
 
 export class HTTP {
     public authToken: string;
@@ -7,19 +8,25 @@ export class HTTP {
     constructor(protected client: Client) {}
 
     public get<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return get(this.client['getHttpEndpoint'](path), this.getOptions(options));
+        return this.request("get", path, options);
     }
 
     public post<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return post(this.client['getHttpEndpoint'](path), this.getOptions(options));
+        return this.request("post", path, options);
     }
 
     public del<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return del(this.client['getHttpEndpoint'](path), this.getOptions(options));
+        return this.request("del", path, options);
     }
 
     public put<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
-        return put(this.client['getHttpEndpoint'](path), this.getOptions(options));
+        return this.request("put", path, options);
+    }
+
+    protected request(method: "get" | "post" | "put" | "del", path: string, options: Partial<Options> = {}): Promise<Response> {
+        return httpie[method](this.client['getHttpEndpoint'](path), this.getOptions(options)).catch((e: any) => {
+            throw new ServerError(e.statusCode, e.data?.error || e.statusMessage || e.message);
+        });
     }
 
     protected getOptions(options: Partial<Options>) {

--- a/src/HTTP.ts
+++ b/src/HTTP.ts
@@ -25,7 +25,7 @@ export class HTTP {
 
     protected request(method: "get" | "post" | "put" | "del", path: string, options: Partial<httpie.Options> = {}): Promise<httpie.Response> {
         return httpie[method](this.client['getHttpEndpoint'](path), this.getOptions(options)).catch((e: any) => {
-            throw new ServerError(e.statusCode, e.data?.error || e.statusMessage || e.message);
+            throw new ServerError(e.statusCode || -1, e.data?.error || e.statusMessage || e.message || "offline");
         });
     }
 

--- a/src/HTTP.ts
+++ b/src/HTTP.ts
@@ -1,8 +1,8 @@
-import { Client } from "../Client";
+import { Client } from "./Client";
 import { post, get, put, del, Response, Options } from "httpie";
 
 export class HTTP {
-    public token: string;
+    public authToken: string;
 
     constructor(protected client: Client) {}
 
@@ -23,9 +23,12 @@ export class HTTP {
     }
 
     protected getOptions(options: Partial<Options>) {
-        if (this.token) {
-            if (!options.headers) { options.headers = {}; }
-            options.headers['Authorization'] = `Bearer ${this.token}`;
+        if (this.authToken) {
+            if (!options.headers) {
+                options.headers = {};
+            }
+
+            options.headers['Authorization'] = `Bearer ${this.authToken}`;
         }
 
         return options;

--- a/src/HTTP.ts
+++ b/src/HTTP.ts
@@ -1,35 +1,35 @@
 import { Client } from "./Client";
 import { ServerError } from "./errors/ServerError";
-import httpie, { Response, Options } from "httpie";
+import * as httpie from "httpie";
 
 export class HTTP {
     public authToken: string;
 
     constructor(protected client: Client) {}
 
-    public get<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+    public get<T = any>(path: string, options: Partial<httpie.Options> = {}): Promise<httpie.Response<T>> {
         return this.request("get", path, options);
     }
 
-    public post<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+    public post<T = any>(path: string, options: Partial<httpie.Options> = {}): Promise<httpie.Response<T>> {
         return this.request("post", path, options);
     }
 
-    public del<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+    public del<T = any>(path: string, options: Partial<httpie.Options> = {}): Promise<httpie.Response<T>> {
         return this.request("del", path, options);
     }
 
-    public put<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+    public put<T = any>(path: string, options: Partial<httpie.Options> = {}): Promise<httpie.Response<T>> {
         return this.request("put", path, options);
     }
 
-    protected request(method: "get" | "post" | "put" | "del", path: string, options: Partial<Options> = {}): Promise<Response> {
+    protected request(method: "get" | "post" | "put" | "del", path: string, options: Partial<httpie.Options> = {}): Promise<httpie.Response> {
         return httpie[method](this.client['getHttpEndpoint'](path), this.getOptions(options)).catch((e: any) => {
             throw new ServerError(e.statusCode, e.data?.error || e.statusMessage || e.message);
         });
     }
 
-    protected getOptions(options: Partial<Options>) {
+    protected getOptions(options: Partial<httpie.Options>) {
         if (this.authToken) {
             if (!options.headers) {
                 options.headers = {};

--- a/src/core/HTTP.ts
+++ b/src/core/HTTP.ts
@@ -1,0 +1,33 @@
+import { Client } from "../Client";
+import { post, get, put, del, Response, Options } from "httpie";
+
+export class HTTP {
+    public token: string;
+
+    constructor(protected client: Client) {}
+
+    public get<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+        return get(this.client['getHttpEndpoint'](path), options);
+    }
+
+    public post<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+        return post(this.client['getHttpEndpoint'](path), options);
+    }
+
+    public del<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+        return del(this.client['getHttpEndpoint'](path), options);
+    }
+
+    public put<T = any>(path: string, options: Partial<Options> = {}): Promise<Response<T>> {
+        return put(this.client['getHttpEndpoint'](path), options);
+    }
+
+    protected getOptions(options: Partial<Options>) {
+        if (this.token) {
+            if (!options.headers) { options.headers = {}; }
+            options.headers['Authorization'] = `Bearer ${this.token}`;
+        }
+
+        return options;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import './legacy';
 export { Client, JoinOptions } from './Client';
 export { Protocol, ErrorCode } from './Protocol';
 export { Room, RoomAvailable } from './Room';
-export { Auth, Platform, Device } from "./Auth";
+export { Auth, type AuthSettings, type PopupSettings } from "./Auth";
 
 /*
  * Serializers

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -1,0 +1,30 @@
+import './util';
+import assert from "assert";
+import { Client, Room } from "../src";
+
+describe("Auth", function() {
+    let client: Client;
+
+    before(() => {
+        client = new Client("ws://localhost:2546");
+    });
+
+    describe("store token", () => {
+        it("should store token on localStorage", () => {
+            client.auth['emitChange']({ user: {}, token: "123" });
+            assert.strictEqual("123", client.auth.token);
+            assert.strictEqual("123", window.localStorage.getItem(client.auth.settings.key));
+        });
+
+        it("should reject if no token is stored", async () => {
+            // @ts-ignore
+            client.auth.token = undefined;
+
+            await assert.rejects(async () => {
+                await client.auth.getUserData();
+            }, /missing auth.token/);
+        });
+
+    });
+
+});

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -1,6 +1,7 @@
 import './util';
 import assert from "assert";
 import { Client, Room } from "../src";
+import { AuthData } from '../src/Auth';
 
 describe("Auth", function() {
     let client: Client;
@@ -23,6 +24,22 @@ describe("Auth", function() {
             await assert.rejects(async () => {
                 await client.auth.getUserData();
             }, /missing auth.token/);
+        });
+
+    });
+
+    describe("onChange", () => {
+        it("should trigger onChange when token is set", () => {
+            let onChangePayload: AuthData | undefined = undefined;
+            client.auth.onChange((data) => onChangePayload = data);
+            client.auth['emitChange']({ user: { dummy: true }, token: "123" });
+            assert.strictEqual("123", client.auth.token);
+            assert.strictEqual("123", client.http.authToken);
+
+            client.auth.onChange((data) => onChangePayload = data);
+            client.auth['emitChange']({ user: { dummy: true }, token: null } as any);
+            assert.strictEqual(null, client.auth.token);
+            assert.strictEqual(null, client.http.authToken);
         });
 
     });

--- a/test/client_test.ts
+++ b/test/client_test.ts
@@ -18,25 +18,25 @@ describe("Client", function () {
             const settingsByUrl = {
                 'ws://localhost:2567': {
                     settings: { hostname: "localhost", port: 2567, secure: false, },
-                    httpEndpoint: "http://localhost:2567",
+                    httpEndpoint: "http://localhost:2567/",
                     wsEndpoint: "ws://localhost:2567/processId/roomId?",
                     wsEndpointPublicAddress: "ws://node-1.colyseus.cloud/processId/roomId?"
                 },
                 'wss://localhost:2567': {
                     settings: { hostname: "localhost", port: 2567, secure: true, },
-                    httpEndpoint: "https://localhost:2567",
+                    httpEndpoint: "https://localhost:2567/",
                     wsEndpoint: "wss://localhost:2567/processId/roomId?",
                     wsEndpointPublicAddress: "wss://node-1.colyseus.cloud/processId/roomId?"
                 },
                 'http://localhost': {
                     settings: { hostname: "localhost", port: 80, secure: false, },
-                    httpEndpoint: "http://localhost",
+                    httpEndpoint: "http://localhost/",
                     wsEndpoint: "ws://localhost/processId/roomId?",
                     wsEndpointPublicAddress: "ws://node-1.colyseus.cloud/processId/roomId?"
                 },
                 'https://localhost/custom/path': {
                     settings: { hostname: "localhost", port: 443, secure: true, pathname: "/custom/path" },
-                    httpEndpoint: "https://localhost/custom/path",
+                    httpEndpoint: "https://localhost/custom/path/",
                     wsEndpoint: "wss://localhost/custom/path/processId/roomId?",
                     wsEndpointPublicAddress: "wss://node-1.colyseus.cloud/processId/roomId?"
                 },
@@ -49,7 +49,7 @@ describe("Client", function () {
                 assert.strictEqual(expected.settings.hostname, settings.hostname);
                 assert.strictEqual(expected.settings.port, settings.port);
                 assert.strictEqual(expected.settings.secure, settings.secure);
-                assert.strictEqual(expected.httpEndpoint + "/matchmake/", client['getHttpEndpoint']());
+                assert.strictEqual(expected.httpEndpoint, client['getHttpEndpoint']());
                 assert.strictEqual(expected.wsEndpoint, client['buildEndpoint'](room));
                 assert.strictEqual(expected.wsEndpointPublicAddress, client['buildEndpoint'](roomWithPublicAddress));
 
@@ -57,7 +57,7 @@ describe("Client", function () {
                 assert.strictEqual(expected.settings.hostname, clientWithSettings['settings'].hostname);
                 assert.strictEqual(expected.settings.port, clientWithSettings['settings'].port);
                 assert.strictEqual(expected.settings.secure, clientWithSettings['settings'].secure);
-                assert.strictEqual(expected.httpEndpoint + "/matchmake/", clientWithSettings['getHttpEndpoint']());
+                assert.strictEqual(expected.httpEndpoint, clientWithSettings['getHttpEndpoint']());
                 assert.strictEqual(expected.wsEndpoint, clientWithSettings['buildEndpoint'](room));
                 assert.strictEqual(expected.wsEndpointPublicAddress, clientWithSettings['buildEndpoint'](roomWithPublicAddress));
             }


### PR DESCRIPTION
Integration for https://github.com/colyseus/colyseus/pull/657

---

Introduces the following APIs:

### `client.auth` API:

- `client.auth.registerWithEmailAndPassword(email, password, options?)`
- `client.auth.signInWithEmailAndPassword(email, password)`
- `client.auth.signInAnonymously(options?)`
- `client.auth.signInWithProvider(providerName)` - open popup for OAuth provider
- `client.auth.sendPasswordResetEmail(email)`
- `client.auth.getUserData()` - requests `/auth/userdata` from the server
- `client.auth.onChange(callback)` - define a callback that is triggered when internal auth state changes (it only triggers as a response from `client.auth` method calls, there's no realtime subscription here!)
- `client.auth.signOut()` - clear local auth token
- `client.auth.token` - auth token getter and setter

### `client.http` API:

If `client.auth.token` is set, requests from `client.http` will forward it as `"Authentication: Bearer {token}"`  header. The match-making requests are now using `client.http` as well.

- `client.http.get(path, options)`
- `client.http.post(path, options)`
- `client.http.del(path, options)`
- `client.http.put(path, options)`