### PR TITLE
 Checking if either roomId or token is null when splitting the reconnectionToken, meaning that the reconnectionToken format is invalid

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -100,6 +100,9 @@ export class Client {
             throw new Error("DEPRECATED: .reconnect() now only accepts 'reconnectionToken' as argument.\nYou can get this token from previously connected `room.reconnectionToken`");
         }
         const [roomId, token] = reconnectionToken.split(":");
+		if (!roomId || !token) {
+			throw new Error("Invalid reconnection token format.\nThe format should be roomId:reconnectionToken");
+		}
         return await this.createMatchMakeRequest<T>('reconnect', roomId, { reconnectionToken: token }, rootSchema);
     }
 


### PR DESCRIPTION
I think the user should be warned that the reconnectionToken has a specific format, It's not obvious that one should include the roomId along the reconnectionToken when using the server-side stored client._reconnectionToken