### PR TITLE
Add in place reconnection functionality for auto-reconnect on "abnormal closure" (error 1006)

### DIFF
--- a/src/Room.ts
+++ b/src/Room.ts
@@ -32,6 +32,7 @@ export class Room<State= any> {
     // Public signals
     public onStateChange = createSignal<(state: State) => void>();
     public onError = createSignal<(code: number, message?: string) => void>();
+    public onClose = createSignal<(code: number) => void>();
     public onLeave = createSignal<(code: number) => void>();
     protected onJoin = createSignal();
 
@@ -75,6 +76,12 @@ export class Room<State= any> {
             if (!room.hasJoined) {
                 console.warn?.(`Room connection was closed unexpectedly (${e.code}): ${e.reason}`);
                 room.onError.invoke(e.code, e.reason);
+                return;
+            }
+            // allow the user to throw an error in onClose to cancel leaving
+            try {
+                room.onClose.invoke(e.code);
+            } catch (error) {
                 return;
             }
             if (e.code === CloseCode.DEVMODE_RESTART && devModeCloseCallback) {


### PR DESCRIPTION
Use case:
```ts
room.onClose((code) => {
    // Reconnect on abnormal closure 
    if (code === 1006) {
        client.reconnect(room);
        throw new Error("Reconnecting");
    }
});
```
My reasoning for adding a new event handler `onClose` is to not alter the function of existing codebases.

`onClose` handler will happen when the connection closes before `onLeave` and will cancel leaving and destroying the room if an error is thrown within the callback.

`client.reconnect<T>(room: Room<T>)` is a new overload.
It will connect in place to an existing room the user is already connected to, therefore not invalidating the state of the existing room and allowing it to be reused.