### PR TITLE
Add support to handle ServerError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { Client, JoinOptions } from './Client';
 export { Protocol, ErrorCode, SeatReservation } from './Protocol';
 export { Room, RoomAvailable } from './Room';
 export { Auth, type AuthSettings, type PopupSettings } from "./Auth";
+export { ServerError } from './errors/ServerError';
 
 /*
  * Serializers


### PR DESCRIPTION
When trying to handle errors from the http request in typescript, we don't have a way to get intellisense.

## Example

**Current**:
```ts
import { Client } from "colyseus.js";

// Tricky way if you want to do it in the current build, but you can only get the type and not the class, so you can't do `instanceof`.
import { type ServerError } from "colyseus.js/lib/errors/ServerError"; 

const client = new Client("http://localhost:2567");

function login() {
  try {
    await client.auth.getUserData(); // Error because we don't login before.
  } catch(error: any) {
    if (error && error.name === "ServerError") {
      // This is the only way to handle the error.
    }
  }
}
```

Now:
```ts
import { Client, ServerError } from "colyseus.js";
const client = new Client("http://localhost:2567");

function login() {
  try {
    await client.auth.getUserData(); // Error because we don't login before.
  } catch(error: any) {
    if (error instanceof ServerError) {
      error.message; // It's a string, It works!!!!
    }
  }
}
```