### PR TITLE
Expose MatchMakeError and add name to error

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -13,6 +13,7 @@ export class MatchMakeError extends Error {
     constructor(message: string, code: number) {
         super(message);
         this.code = code;
+        this.name = "MatchMakeError";
         Object.setPrototypeOf(this, MatchMakeError.prototype);
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import './legacy';
 
-export { Client, JoinOptions } from './Client';
+export { Client, JoinOptions, MatchMakeError } from './Client';
 export { Protocol, ErrorCode, SeatReservation } from './Protocol';
 export { Room, RoomAvailable } from './Room';
 export { Auth, type AuthSettings, type PopupSettings } from "./Auth";


### PR DESCRIPTION
This will allow for better error checking like so:
```js
import { MatchMakeError } from "colyseus.js"

try {
	room = await client.joinById(roomId)
} catch(err) {
	if(err instanceof MatchMakeError) {
		// handle matchmaking specific error
	}
	throw err
}
```

This will also allow checking by name using `err.name`, although the above is the more *correct* way of doing it.